### PR TITLE
Cleaned makefiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
 branches:
     only:
         - typescript
-install: make prepare
 script: make && make test
 notifications:
     on_failure: always

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@ include ./make/utils/define-cmd.mk
 
 all: server bouncing-cube
 
-./node_modules/.dirstamp:
+PREPARE_DEPENDENCY=./node_modules/.dirstamp
+
+$(PREPARE_DEPENDENCY):
 	@$(ECHO) "$(STYLE_PREPARE)Installing global dependencies$(COLOR_DEFAULT)"
 	@npm --loglevel error --progress false install typescript@next ts-loader webpack webpack-fail-plugin $(TO_NULL)
 	@$(TOUCH_DIRSTAMP)
 
-prepare: ./node_modules/.dirstamp
+prepare: $(PREPARE_DEPENDENCY)
 
 include ./make/include.mk
 

--- a/make/makefiles/bouncing.mk
+++ b/make/makefiles/bouncing.mk
@@ -1,22 +1,22 @@
 $(MODULES)/bouncing-cube/typings: $(MODULES)/bouncing-cube/typings/typings/.dirstamp $(MODULES)/bouncing-cube/typings/custom/.dirstamp
 
-$(MODULES)/bouncing-cube/typings/typings/.dirstamp: $(MODULES)/bouncing-cube/typings/typings.json
+$(MODULES)/bouncing-cube/typings/typings/.dirstamp: $(PREPARE_DEPENDENCY) $(MODULES)/bouncing-cube/typings/typings.json
 	@$(call LOG_TYPINGS,bouncing-cube)
 	@$(CD) $(MODULES)/bouncing-cube/typings && $(TYPINGS) install
 	@$(TOUCH_DIRSTAMP)
 
-$(MODULES)/bouncing-cube/typings/custom/.dirstamp: $(CUSTOM_TYPINGS_SRC)
+$(MODULES)/bouncing-cube/typings/custom/.dirstamp: $(PREPARE_DEPENDENCY) $(CUSTOM_TYPINGS_SRC)
 	@$(call LOG_CUSTOM,bouncing-cube)
 	@$(MKDIRP) $(MODULES)/bouncing-cube/typings/custom/
 	@$(MERGE) custom_typings $(MODULES)/bouncing-cube/typings/custom
 	@$(TOUCH_DIRSTAMP)
 
-$(MODULES)/bouncing-cube/node_modules/.dirstamp: $(MODULES)/bouncing-cube/package.json $(L3D_DEPENDENCY)
+$(MODULES)/bouncing-cube/node_modules/.dirstamp: $(PREPARE_DEPENDENCY) $(MODULES)/bouncing-cube/package.json $(L3D_DEPENDENCY)
 	@$(call LOG_DEPENDENCIES,bouncing-cube)
 	@$(CD) $(MODULES)/bouncing-cube/ && $(NPM_UNINSTALL) l3d && $(NPM_INSTALL)
 	@$(TOUCH_DIRSTAMP)
 
-$(MODULES)/bouncing-cube/bin/bouncing.min.js: $(call FIND,$(MODULES)/bouncing-cube/src/,*) $(MODULES)/bouncing-cube/node_modules/.dirstamp $(MODULES)/bouncing-cube/tsconfig.json $(MODULES)/bouncing-cube/typings $(MODULES)/bouncing-cube/config.js
+$(MODULES)/bouncing-cube/bin/bouncing.min.js: $(PREPARE_DEPENDENCY) $(call FIND,$(MODULES)/bouncing-cube/src/,*) $(MODULES)/bouncing-cube/node_modules/.dirstamp $(MODULES)/bouncing-cube/tsconfig.json $(MODULES)/bouncing-cube/typings $(MODULES)/bouncing-cube/config.js
 	@$(call LOG_BUILDING,bouncing-cube)
 	@$(NODE) $(MODULES)/bouncing-cube/config.js
 	@$(call LOG_BUILT,bouncing-cube)

--- a/make/makefiles/config.mk
+++ b/make/makefiles/config.mk
@@ -1,13 +1,13 @@
 CONFIG_DEPENDENCY=$(MODULES)/config/lib/.dirstamp
 config: $(CONFIG_DEPENDENCY)
 
-$(MODULES)/config/lib/.dirstamp: $(MODULES)/config/config.ts $(MODULES)/config/package.json $(MODULES)/config/tsconfig.json
+$(MODULES)/config/lib/.dirstamp: $(PREPARE_DEPENDENCY) $(MODULES)/config/config.ts $(MODULES)/config/package.json $(MODULES)/config/tsconfig.json
 	@$(call LOG_BUILDING,config)
 	@$(CD) $(MODULES)/config/ && $(TSC)
 	@$(TOUCH_DIRSTAMP)
 	@$(call LOG_BUILT,config)
 
-$(MODULES)/config/bin/config.js: $(MODULES)/config/config.ts $(MODULES)/config/package.json $(MODULES)/config/tsconfig.json
+$(MODULES)/config/bin/config.js: $(PREPARE_DEPENDENCY) $(MODULES)/config/config.ts $(MODULES)/config/package.json $(MODULES)/config/tsconfig.json
 	@$(CD) $(MODULES)/config/ && $(NODE) config.js
 
 

--- a/make/makefiles/demo.mk
+++ b/make/makefiles/demo.mk
@@ -1,7 +1,7 @@
 DEMO_DEPENDENCY=$(MODULES)/demo/bin/demo.js
 demo: $(DEMO_DEPENDENCY)
 
-$(MODULES)/demo/typings/typings/.dirstamp: $(MODULES)/demo/typings/typings.json
+$(MODULES)/demo/typings/typings/.dirstamp: $(PREPARE_DEPENDENCY) $(MODULES)/demo/typings/typings.json
 	@$(call LOG_TYPINGS,demo)
 	@$(CD) $(MODULES)/demo/typings/ && $(TYPINGS) install
 	@$(TOUCH_DIRSTAMP)
@@ -12,7 +12,7 @@ $(MODULES)/demo/typings/custom/.dirstamp: $(CUSTOM_TYPINGS_SRC)
 	@$(MERGE) ./custom_typings $(MODULES)/demo/typings/custom
 	@$(TOUCH_DIRSTAMP)
 
-$(MODULES)/demo/typings/.dirstamp: $(MODULES)/demo/typings/typings/.dirstamp $(MODULES)/demo/typings/custom/.dirstamp
+$(MODULES)/demo/typings/.dirstamp: $(PREPARE_DEPENDENCY) $(MODULES)/demo/typings/typings/.dirstamp $(MODULES)/demo/typings/custom/.dirstamp
 	@$(TOUCH_DIRSTAMP)
 
 $(MODULES)/demo/node_modules/.dirstamp: $(MODULES)/demo/package.json $(L3D_DEPENDENCY) $(L3DP_DEPENDENCY) $(CONFIG_DEPENDENCY)
@@ -20,7 +20,7 @@ $(MODULES)/demo/node_modules/.dirstamp: $(MODULES)/demo/package.json $(L3D_DEPEN
 	@$(CD) $(MODULES)/demo/ && $(NPM_UNINSTALL) config l3d l3dp && $(NPM_INSTALL)
 	@$(TOUCH_DIRSTAMP)
 
-$(MODULES)/demo/bin/demo.js: $(MODULES)/demo/main.ts $(MODULES)/demo/node_modules/.dirstamp $(MODULES)/demo/tsconfig.json $(MODULES)/demo/typings/.dirstamp $(MODULES)/demo/config.js $(MODULES)/l3d/bin/l3d.js $(MODULES)/l3dp/bin/l3dp.js $(MODULES)/mth/bin/mth.js
+$(MODULES)/demo/bin/demo.js: $(PREPARE_DEPENDENCY) $(MODULES)/demo/main.ts $(MODULES)/demo/node_modules/.dirstamp $(MODULES)/demo/tsconfig.json $(MODULES)/demo/typings/.dirstamp $(MODULES)/demo/config.js $(MODULES)/l3d/bin/l3d.js $(MODULES)/l3dp/bin/l3dp.js $(MODULES)/mth/bin/mth.js
 	@$(call LOG_BUILDING,demo)
 	@$(NODE) $(MODULES)/demo/config.js
 	@$(call LOG_BUILT,demo)

--- a/make/makefiles/l3d.mk
+++ b/make/makefiles/l3d.mk
@@ -3,7 +3,7 @@ l3d: $(L3D_DEPENDENCY)
 
 $(MODULES)/l3d/typings: $(MODULES)/l3d/typings/typings/.dirstamp $(MODULES)/l3d/typings/custom/.dirstamp
 
-$(MODULES)/l3d/typings/typings/.dirstamp: $(MODULES)/l3d/typings/typings.json
+$(MODULES)/l3d/typings/typings/.dirstamp: $(PREPARE_DEPENDENCY) $(MODULES)/l3d/typings/typings.json
 	@$(call LOG_TYPINGS,l3d)
 	@$(CD) $(MODULES)/l3d/typings && $(TYPINGS) install
 	@$(TOUCH_DIRSTAMP)
@@ -19,13 +19,13 @@ $(MODULES)/l3d/node_modules/.dirstamp: $(MODULES)/l3d/package.json $(MTH_COMMONJ
 	@$(CD) $(MODULES)/l3d/ && $(NPM_UNINSTALL) mth config && $(NPM_INSTALL)
 	@$(TOUCH_DIRSTAMP)
 
-$(MODULES)/l3d/lib/.dirstamp: $(call FIND,$(MODULES)/l3d/src/,*) $(MODULES)/l3d/node_modules/.dirstamp $(MODULES)/l3d/tsconfig-backend.json $(MODULES)/l3d/backend.config.js $(MODULES)/l3d/typings/typings/.dirstamp $(MODULES)/l3d/typings/custom/.dirstamp
+$(MODULES)/l3d/lib/.dirstamp: $(PREPARE_DEPENDENCY) $(call FIND,$(MODULES)/l3d/src/,*) $(MODULES)/l3d/node_modules/.dirstamp $(MODULES)/l3d/tsconfig-backend.json $(MODULES)/l3d/backend.config.js $(MODULES)/l3d/typings/typings/.dirstamp $(MODULES)/l3d/typings/custom/.dirstamp
 	@$(call LOG_BUILDING,l3d)
 	@$(NODE) $(MODULES)/l3d/backend.config.js
 	@$(TOUCH_DIRSTAMP)
 	@$(call LOG_BUILT,l3d)
 
-$(MODULES)/l3d/bin/l3d.js: $(call FIND,$(MODULES)/l3d/src/,*) $(MODULES)/l3d/node_modules/.dirstamp $(MODULES)/l3d/tsconfig-backend.json $(MODULES)/l3d/backend.config.js $(MODULES)/l3d/typings/typings/.dirstamp $(MODULES)/l3d/typings/custom/.dirstamp
+$(MODULES)/l3d/bin/l3d.js: $(PREPARE_DEPENDENCY) $(call FIND,$(MODULES)/l3d/src/,*) $(MODULES)/l3d/node_modules/.dirstamp $(MODULES)/l3d/tsconfig-backend.json $(MODULES)/l3d/backend.config.js $(MODULES)/l3d/typings/typings/.dirstamp $(MODULES)/l3d/typings/custom/.dirstamp
 	@$(CD) $(MODULES)/l3d/ && $(NODE) frontend.config.js
 
 clean-l3d:

--- a/make/makefiles/l3dp.mk
+++ b/make/makefiles/l3dp.mk
@@ -3,7 +3,7 @@ l3dp: $(L3DP_DEPENDENCY)
 
 $(MODULES)/l3dp/typings: $(MODULES)/l3dp/typings/typings/.dirstamp $(MODULES)/l3dp/typings/custom/.dirstamp
 
-$(MODULES)/l3dp/typings/typings/.dirstamp: $(MODULES)/l3dp/typings/typings.json
+$(MODULES)/l3dp/typings/typings/.dirstamp: $(PREPARE_DEPENDENCY) $(MODULES)/l3dp/typings/typings.json
 	@$(call LOG_TYPINGS,l3dp)
 	@$(CD) $(MODULES)/l3dp/typings && $(TYPINGS) install
 	@$(TOUCH_DIRSTAMP)
@@ -19,13 +19,13 @@ $(MODULES)/l3dp/node_modules/.dirstamp: $(MODULES)/l3dp/package.json $(L3D_DEPEN
 	@$(CD) $(MODULES)/l3dp/ && $(NPM_UNINSTALL) config l3d mth && $(NPM_INSTALL)
 	@$(TOUCH_DIRSTAMP)
 
-$(MODULES)/l3dp/lib/.dirstamp: $(call FIND,$(MODULES)/l3dp/src/,*) $(MODULES)/l3dp/node_modules/.dirstamp $(MODULES)/l3dp/tsconfig-backend.json $(MODULES)/l3dp/backend.config.js $(MODULES)/l3dp/typings
+$(MODULES)/l3dp/lib/.dirstamp: $(PREPARE_DEPENDENCY) $(call FIND,$(MODULES)/l3dp/src/,*) $(MODULES)/l3dp/node_modules/.dirstamp $(MODULES)/l3dp/tsconfig-backend.json $(MODULES)/l3dp/backend.config.js $(MODULES)/l3dp/typings
 	@$(call LOG_BUILDING,l3dp)
 	@$(NODE) $(MODULES)/l3dp/backend.config.js
 	@$(TOUCH_DIRSTAMP)
 	@$(call LOG_BUILT,l3dp)
 
-$(MODULES)/l3dp/bin/l3dp.js: $(call FIND,$(MODULES)/l3dp/src/,*) $(MODULES)/l3dp/node_modules/.dirstamp $(MODULES)/l3dp/tsconfig-backend.json $(MODULES)/l3dp/backend.config.js $(MODULES)/l3dp/typings
+$(MODULES)/l3dp/bin/l3dp.js: $(PREPARE_DEPENDENCY) $(call FIND,$(MODULES)/l3dp/src/,*) $(MODULES)/l3dp/node_modules/.dirstamp $(MODULES)/l3dp/tsconfig-backend.json $(MODULES)/l3dp/backend.config.js $(MODULES)/l3dp/typings
 	@$(CD) $(MODULES)/l3dp/ && $(NODE) frontend.config.js
 
 clean-l3dp:

--- a/make/makefiles/mth.mk
+++ b/make/makefiles/mth.mk
@@ -1,7 +1,7 @@
 MTH_COMMONJS_DEPENDENCY=$(MODULES)/mth/lib/.dirstamp
 mth: $(MTH_COMMONJS_DEPENDENCY)
 
-$(MODULES)/mth/typings/.dirstamp: $(MODULES)/mth/typings.json
+$(MODULES)/mth/typings/.dirstamp: $(PREPARE_DEPENDENCY) $(MODULES)/mth/typings.json
 	@$(call LOG_TYPINGS,mth)
 	@$(CD) $(MODULES)/mth/ && $(TYPINGS) install
 	@$(TOUCH_DIRSTAMP)
@@ -11,16 +11,16 @@ $(MODULES)/mth/node_modules/.dirstamp: $(MODULES)/mth/package.json
 	@$(CD) $(MODULES)/mth/ && $(NPM_INSTALL)
 	@$(TOUCH_DIRSTAMP)
 
-$(MODULES)/mth/lib/.dirstamp: $(call FIND,$(MODULES)/mth/src/,*.ts) $(MODULES)/mth/package.json $(MODULES)/mth/tsconfig.json $(MODULES)/mth/typings/.dirstamp $(MODULES)/mth/node_modules/.dirstamp
+$(MODULES)/mth/lib/.dirstamp: $(PREPARE_DEPENDENCY) $(call FIND,$(MODULES)/mth/src/,*.ts) $(MODULES)/mth/package.json $(MODULES)/mth/tsconfig.json $(MODULES)/mth/typings/.dirstamp $(MODULES)/mth/node_modules/.dirstamp
 	@$(call LOG_BUILDING,mth)
 	@$(CD) $(MODULES)/mth/ && $(TSC)
 	@$(TOUCH_DIRSTAMP)
 	@$(call LOG_BUILT,mth)
 
-$(MODULES)/mth/bin/mth.js: $(call FIND,$(MODULES)/mth/src/,*.ts) $(MODULES)/mth/package.json $(MODULES)/mth/tsconfig.json $(MODULES)/mth/typings/.dirstamp $(MODULES)/mth/node_modules/.dirstamp
+$(MODULES)/mth/bin/mth.js: $(PREPARE_DEPENDENCY) $(call FIND,$(MODULES)/mth/src/,*.ts) $(MODULES)/mth/package.json $(MODULES)/mth/tsconfig.json $(MODULES)/mth/typings/.dirstamp $(MODULES)/mth/node_modules/.dirstamp
 	@$(CD) $(MODULES)/mth/ && $(NODE) config.js
 
-test-mth: $(MTH_COMMONJS_DEPENDENCY)
+test-mth: $(PREPARE_DEPENDENCY) $(MTH_COMMONJS_DEPENDENCY)
 	@$(NODEUNIT) $(MODULES)/mth/lib/src/tests/main.js
 
 clean-mth:

--- a/make/makefiles/server.mk
+++ b/make/makefiles/server.mk
@@ -1,6 +1,6 @@
 $(MODULES)/server/typings: $(MODULES)/server/typings/typings/.dirstamp $(MODULES)/server/typings/custom/.dirstamp
 
-$(MODULES)/server/typings/typings/.dirstamp: $(MODULES)/server/typings/typings.json
+$(MODULES)/server/typings/typings/.dirstamp: $(PREPARE_DEPENDENCY) $(MODULES)/server/typings/typings.json
 	@$(call LOG_TYPINGS,server)
 	@$(CD) $(MODULES)/server/typings && $(TYPINGS) install
 	@$(TOUCH_DIRSTAMP)
@@ -16,7 +16,7 @@ $(MODULES)/server/node_modules/.dirstamp: $(MODULES)/server/package.json $(L3D_D
 	@$(CD) $(MODULES)/server/ && $(NPM_UNINSTALL) l3d l3dp config mth && $(NPM_INSTALL)
 	@$(TOUCH_DIRSTAMP)
 
-$(MODULES)/server/bin/.dirstamp: $(call FIND,$(MODULES)/server/src/,*.ts) $(call FIND,$(MODULES)/server/src,*.jade) $(MODULES)/server/node_modules/.dirstamp $(MODULES)/server/typings
+$(MODULES)/server/bin/.dirstamp: $(PREPARE_DEPENDENCY) $(call FIND,$(MODULES)/server/src/,*.ts) $(call FIND,$(MODULES)/server/src,*.jade) $(MODULES)/server/node_modules/.dirstamp $(MODULES)/server/typings
 	@$(call LOG_BUILDING,server)
 	@$(CD) $(MODULES)/server/ && $(TSC)
 	@$(TOUCH_DIRSTAMP)
@@ -82,10 +82,10 @@ $(MODULES)/server/bin/static/js/l3dp.js: $(MODULES)/l3dp/bin/l3dp.js
 	@$(MKDIRP) $(MODULES)/server/bin/static/js
 	@$(MERGE) $(MODULES)/l3dp/bin/ $(MODULES)/server/bin/static/js
 
-test-server: server
+test-server: $(PREPARE_DEPENDENCY) server
 	@$(CD) $(MODULES)/server/bin/ && $(NODE) server.js --nolisten
 
-run-server: server
+run-server: $(PREPARE_DEPENDENCY) server
 	@$(CD) $(MODULES)/server/bin && $(NODE_OUTPUT) server.js
 
 clean-server:


### PR DESCRIPTION
Added `prepare` as a dependency of everything that needs those scripts
in order to avoid having to run `make prepare` before running `make` : 

- [x] Add `PREPARE_DEPENDENCY` in `Makefile`
- [x] Add `PREPARE_DEPENDENCY` as dependency of everything that needs it
- [x] Update `.travils.yml`